### PR TITLE
Added missing "id" and "resource" to aptitudes, pools, and gear_text

### DIFF
--- a/aptitudes.json
+++ b/aptitudes.json
@@ -2,31 +2,49 @@
   {
     "name": "cognition",
     "description": "represents your intelligence, problem-solving talent, and capacity for logical analysis.",
-    "short_name": "COG"
+    "short_name": "COG",
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "0418079e-2e71-4863-b6f3-bf48c5b787b6"
   },
   {
     "name": "intuition",
     "description": "is your gut instinct and ability to evaluate on the fly.  It includes physical awareness, creativity, cleverness, and cunning.",
-    "short_name": "INT"
+    "short_name": "INT",
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "db418f01-4e3f-4006-8fd0-324a07239bb1"
   },
   {
     "name": "reflexes",
     "description": "is your coordination, manual dexterity, nimbleness, balance, and reaction speed.",
-    "short_name": "REF"
+    "short_name": "REF",
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "21caa481-ba04-494d-b656-bb81c384c991"
   },
   {
     "name": "savvy",
     "description": "represents your social awareness, adaptability, empathy, and ability to influence others.",
-    "short_name": "SAV"
+    "short_name": "SAV",
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "4e30e2fa-01b1-4602-8fe9-5266d3e43f13"
   },
   {
     "name": "somatics",
     "description": "is how well you can exploit your morph’s physical capabilities, including strength, stamina, and sustained positioning and motion.",
-    "short_name": "SOM"
+    "short_name": "SOM",
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "182669f7-5780-4e4e-9720-33ea286f4ba9"
   },
   {
     "name": "willpower",
     "description": "is your self-control, mental fortitude, and strength of personality.",
-    "short_name": "WIL"
+    "short_name": "WIL",
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "c784602e-1792-4ac9-8d64-8f7d33d7a43a"
   }
 ]

--- a/gear_categories.json
+++ b/gear_categories.json
@@ -1,5 +1,6 @@
-{
-  "Comms": {
+[
+  {
+    "name": "Comms",
     "text": "<p>In a networked world, keeping in touch is key.</p>",
     "subcategories": {
       "Communication Gear": {
@@ -17,9 +18,13 @@
       "Mesh Hardware": {
         "text": "<p>This gear forms the fundamental components of the mesh (Devices, Apps, & Links ▶244).</p>"
       }
-    }
+    },
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "7f11cc89-777b-423d-9064-99a943f7cde5"
   },
-  "Creatures": {
+  {
+    "name": "Creatures",
     "text": "<p>Living creatures cannot be nanofabricated, they must be acquired via Resources trait or rep.</p><p> Training and commanding creatures is handled with Exotic Skill: Animal Handling.</p>",
     "subcategories": {
       "GMOs": {
@@ -31,9 +36,13 @@
       "Xenofauna": {
         "text": "<p>A few creatures discovered on exoplanets have been finding their way into private collections and transhuman habitats.</p>"
       }
-    }
+    },
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "18144825-a978-48f8-925d-8d940b843925"
   },
-  "Drugs": {
+  {
+    "name": "Drugs",
     "text": "<p>The transhuman desire to enhance the body and mind melds neatly with our species' history of recreational substance abuse. Drugs of all kinds — chemical, nano, or electronic — are not only popular but widespread. Advances in biotechnology have eliminated many of the side effects, but transhuman bodies are complicated environments, so they remain a factor, especially with long-term use.</p><p> Drugs are available in a variety of forms: pills, slap patches, inhalers, disposable injectors, liquids, powders, etc. The drugs here are just a representative sampling. There are thousands if not millions of drugs in circulation in Eclipse Phase — GMs are encouraged to introduce their own, using these as guidelines.</p><p> Note that some drugs may have different effects on morphs with the Non-Human Biochemistry trait (GM discretion).</p><p> <b>Complexity:</b> The listed Complexity is for 5 doses/applications of the chemical, drug, or toxin.</p> <h3>Drug and Toxin Rules</h3> <p>Every substance has a type (determining what it can affect), an application method (how it is deployed), and an effect (what it does).</p> <h4>Types</h4> There are three classifications: <ul> <li>Biochem: These are natural biological substances and compounds produced by chemical synthesis, nanofab, or enzymatic biosynthesis. Biochem drugs and toxins only affect biomorphs.</li> <li>Nano: Nanodrugs and -toxins are temporary nanobot colonies designed to operate within biological hosts and programmed to create a certain effect. Nanodrugs and -toxins only affect biomorphs.</li> <li>Electronic: These reproduce drug-like effects for infomorphs and egos residing in cyberbrains. E-drugs are sold on the black market as single-use or self-erasing downloads, just like blueprints.</li> </ul> <h4>Application Methods</h4> <p>The application method determines how quickly the substance is absorbed into the body, as noted on the Onset Times table. An onset time of immediate means the effect kicks in at the end of an action turn, an onset time of 1 action turn kicks in at the end of the next turn.</p> <ul> <li>App: Electronic substances are run like other software.</li> <li>Dermal (D): This drug/toxin is absorbed via the skin as either a gas, liquid, or solid (e.g., paste). Slap patches or splash weapons are commonly used, loaded with the chemical DMSO, which transfers the drug through the skin. Slap patches can be applied to others in melee combat with a touch-only (+20) attack. Melee weapons may also be coated (Coated Weapons ▶219).</li> <li>Inhalation (Inh): This is a gas that is breathed into the lungs or snorted nasally. Used for inhalers, aerosols, powders, and gas grenades/seekers.</li> <li>Injected (Inj): This liquid is applied via either an intramuscular or intravenous injection. Used for needles and piercing weapons (Coated Weapons ▶219).</li> <li>Oral (O): This is a liquid or solid that is absorbed through the stomach or oral cavity (eating or drinking). Used with pills and liquids.</li> </ul> <h5>Onset Times</h5> <ul> <li>Dermal - 1 action turn</li> <li>Inhalation - Immediate</li> <li>Injection - 1 action turn</li> <li>Oral - 15 minutes</li> </ul> <h4>Effects</h4> <p>If you are exposed to a drug or toxin via its method of application — for example, you pop a pill, slap on a dermal patch, are soaked with a splash grenade, breathe in gas, or get stabbed with a coated weapon — then you are automatically subject to the substance’s effects. The duration determines how long they last.</p><p> There is no resistance test to ignore a drug or toxin’s effects, but some may call for an aptitude check to determine the effect severity. Defensive Ware: Toxin ﬁlters ▶323 allow a SOM Check to ignore a biochem drug or toxin’s effects outright (they have no effect on nanodrugs or nanotoxins). If an effect calls for an aptitude check, toxin filters apply a +30 modifier. Both toxin filters and medichines will reduce the effects of a biochem drug or toxin (damage, modifiers, etc.) and duration by half; together they nullify the effects entirely. Nanophages reduce the effects/duration of nanodrugs and nanotoxins by half.</p> <h4>Addiction and Abuse</h4> <p>If you over-use a drug, you may find yourself addicted to it. Drugs can be physically addictive (affecting the morph), mentally addictive (affecting the ego), or both. If the GM decides that you are overusing (such as more than once a day, or several times in a week), you must make a WIL Check modified by the drug’s Addiction Modifier. If you fail, you acquire the Addiction Addiction (Level 1) negative trait ▶76. Once addicted, you must take the drug regularly (according to the trait level) or face withdrawal (-10 modifier per level).</p> <p>At the GM’s discretion, heavy or extended drug use may require you to make a WIL Check modified by the Addiction Modifier to avoid increasing your Addiction trait’s level. Drug abuse may also result in other physiological or psychological effects.</p>",
     "subcategories": {
       "Cognitive Drugs": {
@@ -69,9 +78,13 @@
       "Nanotoxins": {
         "text": "<p>These temporary nanobot infestations damage or impair.</p>"
       }
-    }
+    },
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "c05b37a2-9806-4a64-a563-48f435d1a3dc"
   },
-  "Services": {
+  {
+    "name": "Services",
     "text": "<p>Credit and mutual aid can get you many things in Eclipse Phase.</p>",
     "subcategories": {
       "Mesh Services": {
@@ -80,9 +93,13 @@
       "Physical Services": {
         "text": "<p>These services are available on some habitats.</p>"
       }
-    }
+    },
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "cc411933-97c6-4114-bb39-807e8d88a79e"
   },
-  "Software": {
+  {
+    "name": "Software",
     "text": "<p>Neither software nor services are tangible goods, so they cannot be nanofabricated.</p>",
     "subcategories": {
       "Skillsoft": {
@@ -100,9 +117,13 @@
       "TacNet": {
         "text": "<p>See item description.</p>"
       }
-    }
+    },
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "8bd55671-b631-4b75-90d1-482be553c523"
   },
-  "Tech": {
+  {
+    "name": "Tech",
     "text": "<p>Various items, but mostly portable technology that's fairly available.</p>",
     "subcategories": {
       "Bots": {
@@ -147,9 +168,13 @@
       "Swarms": {
         "text": "<p>Swarms are colonies of nanobots or larger microbots created in a hive, programmed with specific instructions, and then set free to perform a set task. Swarms range from thousands of microbots the size of a small insect to millions of nanobots each no bigger than a microbe. Nanobots are invisible to the naked eye, though they can be detected with a nanodetector or nanoscopic vision. A concentrated presence of nanoswarms creates a visible hazy effect in the air. Likewise, mass amounts of expired nanobots leave a toner-like dust residue on nearby surfaces. Microbots are visible but still quite small, the size of a grain of sand or a dust mote, or occasionally as big as a flea.</p><p> Individual “mites” in a swarm are directed by nanocomputers, with behavioral routines modeled on biological insect and animal swarms. They are powered by tiny batteries or solar cells. Swarms stick together and work as a whole, communicating by radio or laser link. They can be tasked with specific instructions or set to follow pre-set routines. They can also be teleoperated or reprogrammed after they are released.</p><p>Swarms are released directly from a hive or from pre-packaged programmable canisters.</p>"
       }
-    }
+    },
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "964d4614-25e5-4792-8cba-3f50d9034907"
   },
-  "Vehicles": {
+  {
+    "name": "Vehicles",
     "text": "<p>In Eclipse Phase, most vehicles are piloted by ALI. You simply get in the vehicle and tell it where to go. Manual piloting is for emergencies, control freaks, and people who don’t like machines. Like robots, vehicles can be remotely operated. They are not equipped for sleeving into, however, unless you add a cyberbrain system.</p>",
     "subcategories": {
       "Aircraft": {
@@ -176,9 +201,13 @@
       "Spacecraft": {
         "text": "<p>Though egocasting and nanofabrication have reduced the need, spacecraft continue to play an important role in transporting goods and people around the Solar System. Both in terms of materials and propulsion, spacecraft in the post-Fall era are far superior to the primitive vessels used in the 20th and early 21st centuries, but they are still based on the same principles.</p><p> Spacecraft are flown with Pilot: Space skill and repaired with Hardware: Aerospace.</p><p> Spacecraft have few stats in Eclipse Phase, as they are primarily handled as setting rather than vehicles. Note also that no stats are given for spacecraft weaponry. It is highly recommended that space combat be handled as a plot device rather than a combat scene, given the extreme lethality and danger involved. If you must know the DV of a spacecraft weapon, treat it as a standard weapon with a DV multiplier of x3 for small craft (fighters and shuttles), x5 for medium craft, and x10 for larger craft.</p>"
       }
-    }
+    },
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "fa332181-7db8-4501-9c37-3a535b28b0e0"
   },
-  "Ware": {
+  {
+    "name": "Ware",
     "text": "<p>Ware is a catch-all category for augmentations of different kinds:</p><ul><li>Bioware (B) includes genetic modifications, nanosurgical tissue alterations, and implantation of bio-engineered organs. It is only available for biomorphs (including pods and uplifts). Because of its organic nature, bioware is hard to detect in scans; genetic testing or other bio-sampling is required. Use Medicine: Biotech to diagnose, implant, or repair.</li><li>Cyberware (C) is synthetic devices either implanted within a biological body or “grown” within using nanobots. It is only available for biomorphs (including pods and uplifts). Cyberware is detectable with x-ray and radar scans. It can also be hacked like other electronics. Use Medicine: Biotech to implant, Hardware: Electronics to repair the ware itself.</li><li>Hardware (H) includes add-ons to synthetic shells. It is only available for synthmorphs, bots, and vehicles. It can be hacked. Use Hardware: Robotics or an appropriate field for vehicles to install, diagnose, and repair. Many non-ware gear items can be mounted on or incorporated into a shell’s frame as hardware (GM discretion).</li><li>Meshware (M) refers to plug-in apps that enhance infomorphs. These may also be installed with cyberbrains. They are vulnerable to mesh combat. Use Program to install, diagnose, or repair.</li><li>Nanoware (N) refers to internal nanobot systems active within a body or shell. Nanoware includes an implanted hive that maintains and refreshes the nanobots. It is available for morphs of all types. Nanoware hives are detectable like cyberware, but the bots are only detectable with nanodetectors or detailed biological sampling. Nanoware can be hacked like other electronics. Use Medicine: Biotech or Hardware: Robotics to implant/repair.</li></ul> <p>Unless otherwise noted, each ware item can only be installed in the same morph once, no matter if it is available in different forms.</p>",
     "subcategories": {
       "Combat": {
@@ -202,9 +231,13 @@
       "Meshware": {
         "text": "<p>Meshware refers to plug-in apps that enhance an infomorph’s capabilities, much like the bioware and hardware for physical morphs. Meshware takes only a complex action to install or uninstall. Once installed, meshware remains with the infomorph when it moves or copies. Meshware can also be installed within cyberbrains. Other apps can also be installed as meshware, so they are embedded within the infomorph. Unlike other apps, meshware cannot be used by non-infomorph/cyberbrained users.</p>"
       }
-    }
+    },
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "9352d3f3-8051-4804-87ee-2b1ee497728d"
   },
-  "Melee Weapons": {
+  {
+    "name": "Melee Weapons",
     "text": "<p>In an era of lethal and incapacitating ranged weaponry, someone equipped for close combat is often at a disadvantage. However, even hardened fighters are wary of getting within reach of certain synthmorphs or heavily augmented biomorphs.</p><p>Except as noted, all melee implements are wielded with Melee skill. Melee ware and weapons may be coated with drugs or toxins (Coated Weapons ▶219) such as poison or nanotoxins secreted from a poison gland ▶322 or implanted nanotoxins ▶335.</p>",
     "subcategories": {
       "Melee Ware": {
@@ -216,9 +249,13 @@
       "Improvised Melee": {
         "text": "<p>hand — or maybe you just think you look cool whaling on someone with a meter of chain. The Improvised Weapons table offers statistics for a few likely ad-hoc items. GMs can use these as guidelines for handling items that aren’t listed. These weapons are wielded with Melee skill, though the GM may rule in some cases that an Exotic Skill is necessary.</p>"
       }
-    }
+    },
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "4c98f1ff-de58-452d-94ec-f33edb982e87"
   },
-  "Ranged Weapons": {
+  {
+    "name": "Ranged Weapons",
     "text": "<p>Ranged combat attacks fall into five categories: beam weapons, kinetic weapons, seeker weapons, spray weapons, and weapon systems. Each is described below.</p><p>Most ranged weapons are constructed from lightweight but hardy ceramic hybrids and refractory metals. They are designed for ambidextrous use and equipped with safety systems ▶216, smartlink systems ▶217, and helper ALIs that automatically mesh with the wielder for firing assistance, target recognition, and tactical networking.</p>",
     "subcategories": {
       "Ranged Ware": {
@@ -245,9 +282,13 @@
       "Seeker/Grenade Ammo": {
         "text": "<p>Seekers and grenades are both compact, multi-function, explosive devices. Seekers are packaged in standard missile, minimissile, or micromissile sizes and fired from seeker weapons using Guns skill. Grenades are designed to be thrown using Athletics skill or placed as traps using Hardware: Explosives. Grenades come in standard form or as minigrenades.</p><p>Minigrenades and micromissiles are the baseline for listed effects. Adjust the effects for minimissiles and standard grenades/ missiles as noted on the table. Most are area-effect weapons ▶218. Each can be set for different trigger conditions ▶213 or to adjust the blast radius ▶218. Seekers/grenades that miss or that hit but are not sticky ▶below and are not set for impact or airburst detonation will scatter ▶218. Listed complexity is for 5 grenades/missiles. Each seeker missile can function as either accushot or homing ammunition ▶211.</p>"
       }
-    }
+    },
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "1641898b-3944-4d7e-b199-00f3a6986ab3"
   },
-  "Armor": {
+  {
+    "name": "Armor",
     "text": "<p>Armor technology has kept pace with weapons development, providing unprecedented levels of protection.</p>",
     "subcategories": {
       "Armor Ware": {
@@ -259,6 +300,9 @@
       "Armor Mods": {
         "text": "<p>Armor modifications add extra materials or coatings that either enhance resistance to certain dangers or provide other effects. Listings are for temporary coatings, which can be applied to clothing, armor, or even directly to a morph’s skin or shell with a spray-on nanobot applicator, are easily removed, and last 1 day. Permanent coatings require a specialized hive ▶342. With the exception of chameleon coating, armor mods are visible and easily identified. Only one mod can be applied at a time.</p>"
       }
-    }
+    },
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "f3b3c0ec-4903-4f43-b58c-af45e5e68fc7"
   }
-}
+]

--- a/pools.json
+++ b/pools.json
@@ -9,7 +9,10 @@
     "checks": [
       "cognition",
       "intuition"
-    ]
+    ],
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "7800682a-d8b9-471d-a6fe-63c161e73cb9"
   },
   {
     "name": "moxie",
@@ -25,7 +28,10 @@
       "willpower",
       "rep",
       "infection"
-    ]
+    ],
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "646e9ec0-de95-4b3b-8ea8-12cdda5b34e6"
   },
   {
     "name": "vigor",
@@ -37,7 +43,10 @@
     "checks": [
       "reflexes",
       "somatics"
-    ]
+    ],
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "aafaf749-c960-4855-ab9f-acf8005798c7"
   },
   {
     "name": "flex",
@@ -47,6 +56,9 @@
       "Define the Environment: You may introduce an environmental factor to a scene. Its presence must be plausible. It should provide a new detail that does not drastically alter the scene. Examples include hiding spots, cover, distractions, shelter, or exploitable elements such as a ladder or window.",
       "Define a Relationship: You may introduce a new, plausible relationship between your character and an existing NPC. This should be a loose/minor connection rather than a close/serious tie. For example, you may have a common friend, shared history, or old but mild rivalry. You may define the rough basics, but the GM determines the finer points and the NPC’s attitude towards your character."
     ],
-    "checks": []
+    "checks": [],
+    "resource": "Eclipse Phase Second Edition",
+    "reference": "",
+    "id": "ab0387d4-f69a-4e4c-b5de-35770c38629d"
   }
 ]


### PR DESCRIPTION
#### Added missing "id" and "resource" to aptitudes and pools. 
#### Renamed gear_text.json and fixed structure.
- Altered gear_text.json's structure so its also arranged as an array of
  objects instead of a string->object map. The former key is added as the
  "name" property of the object so its consistent with other files.
- Renamed it to gear_categories.json since its now an array of categories.